### PR TITLE
CE-12590 Remove setting owner and group for downloaded file

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -88,8 +88,6 @@ action :create do
 
   f = file new_resource.path do
     action :create
-    owner new_resource.owner || ENV['user']
-    group new_resource.group || ENV['user']
     mode new_resource.mode || '0644'
   end
 


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CE-12590)

## Summary of issue

- s3_file resource failing to set owner/group on windows platform when chef is run with System user account.

## Summary of change

Removed setting owner and group and use default (root for linux, Administrator for windows)

## Testing approach

- [ ] Serverspec test (mandatory)
- [x] Manual test
More on ticket.