### PR TITLE
CE-12771: update client Request timeout from 60 seconds to 120.

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -98,7 +98,7 @@ module S3FileLib
           SigV4.sign(request, params, real_region, aws_access_key_id, aws_secret_access_key, token)
         end
       end
-      client::Request.execute(:method => method, :url => "#{url}#{path}", :raw_response => true)
+      client::Request.execute(:method => method, :url => "#{url}#{path}", :raw_response => true, timeout: 120)
     end
   end
 


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CE-12771)

## Code reviewers

## Summary of issue
AWs S3 Api calls to download gems from S3 srepo.coupahost.com  are failing with Timeout Error. 

## Summary of change
Increasing the timeout from 60sec to 120seconds, that would allow Timeout Errors to reduce while downloading gems from S3.

## Testing approach

- [ ] Serverspec test (mandatory)
- [x] Manual test
- [x] Integration

_Please describe your testing approach here. What cases do your tests cover? Did you cover all of the edge cases? What kinds of tests did you write (unit tests? controller tests? integration tests?)? What was your rationale for choosing one kind of test over another for testing each case?_

[1]: https://coupadev.atlassian.net/wiki/display/CD/Guidelines+for+Risk+Levels
[2]: https://coupadev.atlassian.net/wiki/spaces/CO/pages/180696831/Operations+-+Code+Review+Checklist
[3]: https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments
[4]: https://github.com/blog/821
