### PR TITLE
CE-12818: add additional reties when downloading gem from S3

### DIFF
--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -103,8 +103,7 @@ module S3FileLib
         Chef::Log.info("Initiate #{path} download from #{url} ...")
         client::Request.execute(:method => method, :url => "#{url}#{path}", :raw_response => true, timeout: 120)
       rescue => e
-        error = e.respond_to?(:response) ? e.response : e
-        Chef::Log.error(error)
+        Chef::Log.error("Class: #{e.class} \nMessage: #{e.message}")
         if (attempt+=1) < 5
           sleep attempt
           retry

--- a/libraries/s3_file.rb
+++ b/libraries/s3_file.rb
@@ -88,6 +88,7 @@ module S3FileLib
 
   def self.do_request(method, url, bucket, path, aws_access_key_id, aws_secret_access_key, token, region)
     url = build_endpoint_url(bucket, region) if url.nil?
+    attempt = 0
 
     with_region_detect(region) do |real_region|
       client.reset_before_execution_procs
@@ -98,7 +99,18 @@ module S3FileLib
           SigV4.sign(request, params, real_region, aws_access_key_id, aws_secret_access_key, token)
         end
       end
-      client::Request.execute(:method => method, :url => "#{url}#{path}", :raw_response => true, timeout: 120)
+      begin
+        Chef::Log.info("Initiate #{path} download from #{url} ...")
+        client::Request.execute(:method => method, :url => "#{url}#{path}", :raw_response => true, timeout: 120)
+      rescue => e
+        error = e.respond_to?(:response) ? e.response : e
+        Chef::Log.error(error)
+        if (attempt+=1) < 5
+          sleep attempt
+          retry
+        end
+        raise e
+      end
     end
   end
 


### PR DESCRIPTION
## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CE-12818)

## Code reviewers

## Summary of issue
AWS S3 Api calls to download gems from S3 srepo.coupahost.com  are failing with Timeout Error. 

## Summary of change
Add multiple reties that would allow it to get successful on subsequent runs  when downloading gems from S3.

## Testing approach

- [ ] Serverspec test (mandatory)
- [x] Manual test
- [x] Integration

_Please describe your testing approach here. What cases do your tests cover? Did you cover all of the edge cases? What kinds of tests did you write (unit tests? controller tests? integration tests?)? What was your rationale for choosing one kind of test over another for testing each case?_

[1]: https://coupadev.atlassian.net/wiki/display/CD/Guidelines+for+Risk+Levels
[2]: https://coupadev.atlassian.net/wiki/spaces/CO/pages/180696831/Operations+-+Code+Review+Checklist
[3]: https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments
[4]: https://github.com/blog/821
